### PR TITLE
Added statistic class and tests. Formatted Event

### DIFF
--- a/project_sia/src/native_test_suite/statistic.test.js
+++ b/project_sia/src/native_test_suite/statistic.test.js
@@ -1,0 +1,155 @@
+import statistic from '../../../sia-react-native/classes/statistic';
+
+describe("Statistic initialization tests",() => {
+    it("declares a default object successfully", () => {
+        const generated_statistic = new statistic();
+
+        const expected_statistic = {
+            name: "UNSET",
+            description: "UNSET",
+            isBoolean: false,
+            flag: false,
+            quantity: 0
+        };
+
+        expect(generated_statistic).toEqual(expected_statistic);
+    });
+
+    it("declares a object based on passed parameters", () => {
+        const generated_statistic = new statistic(
+            "Sample Stat",
+            "Given Description",
+            true,
+            true,
+            5
+        );
+
+        const expected_statistic = {
+            name: "Sample Stat",
+            description: "Given Description",
+            isBoolean: true,
+            flag: true,
+            quantity: 5
+        };
+
+        expect(generated_statistic).toEqual(expected_statistic);
+    });
+});
+
+describe("Quantity Statistic Modification",() => {
+    it("successfully increments by default value", () => {
+        let generated_statistic = new statistic(
+            "Events Created",
+            "Number of events this user has made",
+            false,
+            false,
+            0
+        );
+
+        generated_statistic.increment();
+
+        const expected_statistic = {
+            name: "Events Created",
+            description: "Number of events this user has made",
+            isBoolean: false,
+            flag: false,
+            quantity: 1
+        };
+
+        expect(generated_statistic).toEqual(expected_statistic);
+    });
+
+    it("successfully increments by passed value", () => {
+        let generated_statistic = new statistic(
+            "Events Created",
+            "Number of events this user has made",
+            false,
+            false,
+            0
+        );
+
+        generated_statistic.increment(4);
+
+        const expected_mid_statistic = {
+            name: "Events Created",
+            description: "Number of events this user has made",
+            isBoolean: false,
+            flag: false,
+            quantity: 4
+        };
+
+        
+
+        expect(generated_statistic).toEqual(expected_mid_statistic);
+
+        generated_statistic.increment(2);
+
+        const expected_end_statistic = {
+            name: "Events Created",
+            description: "Number of events this user has made",
+            isBoolean: false,
+            flag: false,
+            quantity: 6
+        };
+
+        expect(generated_statistic).toEqual(expected_end_statistic);
+    });
+});
+
+describe("Checkbox Statistic Modification",() => {
+    it("successfully flags with default value", () => {
+        let generated_statistic = new statistic(
+            "Backup Email Established",
+            "Identifies if you have set up a backup email",
+            true,
+            false,
+            0
+        );
+
+        generated_statistic.changeFlag();
+
+        const expected_statistic = {
+            name: "Backup Email Established",
+            description: "Identifies if you have set up a backup email",
+            isBoolean: true,
+            flag: true,
+            quantity: 0
+        };
+
+        expect(generated_statistic).toEqual(expected_statistic);
+    });
+
+    it("successfully flags with passed value", () => {
+        let generated_statistic = new statistic(
+            "Backup Email Established",
+            "Identifies if you have set up a backup email",
+            true,
+            false,
+            0
+        );
+
+        generated_statistic.changeFlag();
+
+        const expected_mid_statistic = {
+            name: "Backup Email Established",
+            description: "Identifies if you have set up a backup email",
+            isBoolean: true,
+            flag: true,
+            quantity: 0
+        };
+
+        expect(generated_statistic).toEqual(expected_mid_statistic);
+        
+        generated_statistic.changeFlag(false);
+
+        const expected_end_statistic = {
+            name: "Backup Email Established",
+            description: "Identifies if you have set up a backup email",
+            isBoolean: true,
+            flag: false,
+            quantity: 0
+        };
+
+        expect(generated_statistic).toEqual(expected_end_statistic);
+    });
+});

--- a/sia-react-native/classes/event.js
+++ b/sia-react-native/classes/event.js
@@ -1,4 +1,3 @@
-
 /*Event class is responsible for all scenarios that are of interest to the
 student.
 Includes common information such as name and venue.

--- a/sia-react-native/classes/statistic.js
+++ b/sia-react-native/classes/statistic.js
@@ -1,0 +1,38 @@
+/* Statistic class is responsible for tracking/logging
+a user's action.
+Eg. Number of events created
+*/
+
+class statistic {
+    constructor(
+        name = "UNSET",
+        description = "UNSET",
+        isBoolean = false,
+        flag = false,
+        quantity = 0) {
+        
+        //provides labels for the statistic that the user is able to see
+        this.name = name;
+        this.description = description;
+
+        //provides a marker for the statistics which determines if
+        //not statistics is a checkbox or counter
+        this.isBoolean = isBoolean;
+
+        this.flag = flag;
+        this.quantity = quantity;
+    }
+
+    //changes the statistic's flag. Sets to true by default
+    changeFlag(end_state = true) {
+        this.flag = end_state;
+        return;
+    }
+
+    //increments the statistic's quantity. Adds one by default
+    increment(modifier = 1) {
+        this.quantity = this.quantity + modifier;
+        return;
+    }
+}
+export default statistic;


### PR DESCRIPTION
Currently can mimic EventList code for statisticList/statistics. But unsure if group would prefer a dictionary type access method.

RE this pull request:

Added Statistic class capable of supporting both boolean flagging or quantity flagging.
Added tests for Statistic class

NIT: Modified event class. Blank space left above starting comment. Not needed